### PR TITLE
fix breakage on python 3.9

### DIFF
--- a/itchat/utils.py
+++ b/itchat/utils.py
@@ -18,6 +18,9 @@ logger = logging.getLogger('itchat')
 
 emojiRegex = re.compile(r'<span class="emoji emoji(.{1,10})"></span>')
 htmlParser = HTMLParser()
+if not hasattr(htmlParser, 'unescape'):
+    import html
+    htmlParser.unescape = html.unescape
 try:
     b = u'\u2588'
     sys.stdout.write(b + '\r')


### PR DESCRIPTION
This commit fixes "AttributeError: 'HTMLParser' object has no attribute 'unescape'"

**（阅读后请删除所有内容）**

感谢您的pull request! `itchat`没有你们的帮助很难发展到今天，感谢您的贡献.

以下简单检查项目望您复查:

- [ ] 如果您预计提出两个或更多不相关补丁，请为每个使用不同的pull requests，而不是单一;
- [ ] 所有的pull requests应基于最新的`master`分支;
- [ ] 您预计提出pull requests的分支应有有意义名称，例如`add-this-shining-feature`而不是`develop`;
- [ ] 所有的提交信息与代码中注释应使用可理解的英语.

作为贡献者，您需要知悉

- [ ] 您同意在MIT协议下贡献代码，以便任何人自由使用或分发；当然，你仍旧保留代码的著作权
- [ ] 你不得贡献非自己编写的代码，除非其属于公有领域或使用MIT协议.

不是所有的pull requests都会被合并，然而我认为合并/不合并的补丁一样重要。
如果您认为补丁重要，其他人也有可能这么认为，那么他们可以从你的fork中提取工作并获益。
无论如何，感谢您费心对本项目贡献.

祝好,

LittleCoder, 170308

**（请将本内容完整替换为PULL REQUEST的详细内容）**
